### PR TITLE
Account Creation - Java

### DIFF
--- a/src/main/java/com/softwareengineering/forum/controllers/HomeController.java
+++ b/src/main/java/com/softwareengineering/forum/controllers/HomeController.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -11,9 +12,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-@Controller
+@RestController
 public class HomeController {
-public static String upDir = System.getProperty("user.dir")+"/uploads";
+  public static String upDir = System.getProperty("user.dir") + "/uploads";
 
   @RequestMapping(value = "/")
   public String index() {
@@ -21,20 +22,19 @@ public static String upDir = System.getProperty("user.dir")+"/uploads";
   }
 
   @RequestMapping("/upload")
-  public String upload(Model model, @RequestParam("files") MultipartFile[] files){
+  public String upload(Model model, @RequestParam("files") MultipartFile[] files) {
     StringBuilder Names = new StringBuilder();
-    for(MultipartFile file : files){
+    for (MultipartFile file : files) {
       Path fileNameAndPath = Paths.get(upDir, file.getOriginalFilename());
       Names.append(file.getOriginalFilename());
       try {
         Files.write(fileNameAndPath, file.getBytes());
-      } catch(IOException e){
+      } catch (IOException e) {
         e.printStackTrace();
       }
     }
-    model.addAttribute("msg", "Success! "+Names.toString());
+    model.addAttribute("msg", "Success! " + Names.toString());
     return "uploadstatusview";
   }
-
 
 }

--- a/src/main/java/com/softwareengineering/forum/controllers/MemberController.java
+++ b/src/main/java/com/softwareengineering/forum/controllers/MemberController.java
@@ -2,18 +2,22 @@ package com.softwareengineering.forum.controllers;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.softwareengineering.forum.models.*;
 import com.softwareengineering.forum.services.*;
 
-@Controller
+@RestController
+@CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
 @RequestMapping("/member/")
 class MemberController {
 	@Autowired
@@ -25,10 +29,10 @@ class MemberController {
 		return service.getMemberById(id);
 	}
 
-	@RequestMapping(method = RequestMethod.POST)
+	@PostMapping(value = "createMember", consumes = { MediaType.APPLICATION_JSON_VALUE,
+			MediaType.APPLICATION_XML_VALUE })
 	@ResponseStatus(HttpStatus.CREATED)
-	@ResponseBody
-	public int createMember(@RequestBody Member member) {
-		return service.createMember(member);
+	public void createMember(@RequestBody Member member) {
+		service.createMember(member);
 	}
 }

--- a/src/main/java/com/softwareengineering/forum/models/Member.java
+++ b/src/main/java/com/softwareengineering/forum/models/Member.java
@@ -6,6 +6,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
@@ -17,16 +18,15 @@ import com.softwareengineering.forum.models.*;
 @Table(name = "member")
 public class Member {
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id")
 	private int id;
 	@Column(name = "username", nullable = false, unique = true)
 	private String username;
 	@Column(name = "email", nullable = false, unique = true)
 	private String email;
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, optional = false)
-	@PrimaryKeyJoinColumn
-	private Password password;
+	@Column(name = "password_hash", nullable = false)
+	private String password_hash;
 
 	public Member() {
 	}
@@ -66,11 +66,16 @@ public class Member {
 		this.email = email;
 	}
 
-	public Password getPassword() {
-		return password;
+	public String getPassword() {
+		return this.password_hash;
 	}
 
-	public void setPassword(Password password) {
-		this.password = password;
+	public void setPassword(String password) {
+		this.password_hash = password;
+	}
+
+	@Override
+	public String toString() {
+		return ("Email:\t" + this.email + "\nUsername:\t" + this.username + "\nPassword:\t" + this.password_hash);
 	}
 }

--- a/src/main/java/com/softwareengineering/forum/services/MemberService.java
+++ b/src/main/java/com/softwareengineering/forum/services/MemberService.java
@@ -14,9 +14,8 @@ public class MemberService {
 	@PersistenceContext
 	private EntityManager manager;
 
-	public int createMember(Member member) {
+	public void createMember(Member member) {
 		manager.persist(member);
-		return member.getId();
 	}
 
 	public Member getMemberById(int id) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.datasource.url=jdbc:postgresql://localhost:5432/forum
 spring.datasource.username=forum
 spring.datasource.password=please
+spring.datasource.initialization-mode=always

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -3,12 +3,7 @@ CREATE TABLE IF NOT EXISTS member(
 	username VARCHAR(50) UNIQUE NOT NULL,
 	email VARCHAR(255) UNIQUE NOT NULL,
 	verified BOOLEAN DEFAULT 'n',
-	create_date TIMESTAMP DEFAULT now()
+	create_date TIMESTAMP DEFAULT now(),
+	password_hash VARCHAR(100) NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS password (
-	member_id REFERENCES member(id) ON DELETE CASCADE,
-	password VARCHAR(50) NOT NULL,
-	salt VARCHAR(50) NOT NULL,
-	change_date TIMESTAMP DEFAULT NULL
-);


### PR DESCRIPTION
Closes #4

### Changes in this Branch
- Fixes some issues present in existing code. 
- Allows cross origin requests for local development.
- Combines Password/Member schema for simplicity
A note about the above point: I don't have a problem with password being its own table, particularly if it somehow makes hashing/salting easier, but having it be a simple string attribute is the simplest way to get development done quickly. Until we have a fully working authentication system (possibly addressed in the next sprint) I think we should stick to simple string values.